### PR TITLE
MTG2D-10: Reduce API calls in friends panel

### DIFF
--- a/Assets/Scripts/DataClasses/FriendList.cs
+++ b/Assets/Scripts/DataClasses/FriendList.cs
@@ -6,4 +6,5 @@ using UnityEngine;
 public class FriendList
 {
   public List<int> friends;
+  public List<string> names;
 }

--- a/Assets/Scripts/Hub/Matchmaker.cs
+++ b/Assets/Scripts/Hub/Matchmaker.cs
@@ -7,7 +7,6 @@ using UnityEngine.Networking;
 public class Matchmaker : MonoBehaviour
 {
     public GameObject playMenu;
-    // Once the user has logged in, we can ping the server every X seconds to check if we have open challenges (Idle)
     // Start is called before the first frame update
     void Start()
     {
@@ -24,7 +23,15 @@ public class Matchmaker : MonoBehaviour
     {
       if (PlayerManager.Instance.myID != -1)
       {
-        InvokeRepeating("checkForChallenges", 0.5f, 2f);
+        InvokeRepeating("checkForChallenges", 1f, 3f);
+      }
+    }
+
+    public void stopChallengeChecking()
+    {
+      if (PlayerManager.Instance.myID != -1)
+      {
+        CancelInvoke("checkForChallenges");
       }
     }
 

--- a/Assets/Scripts/Title/TitleScreen.cs
+++ b/Assets/Scripts/Title/TitleScreen.cs
@@ -225,9 +225,6 @@ public class TitleScreen : MonoBehaviour
             // Debug.Log("Deleted all challenges for this user...");
           }
 
-          // Start checking for incoming challenges
-          friendsPanelObject.GetComponent<Matchmaker>().startChallengeChecking();
-
           // Load player decks
           PlayerManager.Instance.loadPlayerDecks();
 


### PR DESCRIPTION
## What does this Pull Request do?

- Friends panel checks for incoming challenges repeatedly only when its open
- Friends panel retrieves friend list from API only once to get both the ids and the usernames
- Friends panel retrieves all sent challenges in one API call (instead of sending a call for each friend individually)