### PR TITLE
MTG2D-25_1: Add colourless cards to card pool

### DIFF
--- a/Assets/Scripts/DeckEditor/CardCollection.cs
+++ b/Assets/Scripts/DeckEditor/CardCollection.cs
@@ -141,7 +141,7 @@ public class CardCollection : MonoBehaviour
               if (!card.isBack)
               {
                 // Colourless
-                if ((card.colourIdentity.Count == 0) && (PlayerManager.Instance.selectedDeck.timeChallengeCardColours.Count == 0))
+                if (card.colourIdentity.Count == 0)
                 {
                   allCardIds.Add(card.id);
                   continue;


### PR DESCRIPTION
## What does this pull request do?

- Adds colourless cards to the pool of available cards in the timed deck building phase, regardless of colour of choice.