### PR TITLE
MTG2D-29: Show english translation of non-english cards in store packs

### DIFF
--- a/Assets/Scripts/PackStore/OpeningDisplayCard.cs
+++ b/Assets/Scripts/PackStore/OpeningDisplayCard.cs
@@ -46,7 +46,15 @@ public class OpeningDisplayCard : MonoBehaviour
       displayCard = GameObject.Find("OpeningDisplayCard");
       displayCardBack = GameObject.Find("OpeningDisplayCardBack");
       displayCard.GetComponent<CanvasGroup>().alpha = 1;
-      displayCard.GetComponent<WebCard>().texturizeCard(card);
+      if (card.hasEnglishTranslation())
+      {
+        CardInfo translatedCard = PlayerManager.Instance.getCardFromLookup(card.variations[0]);
+        displayCard.GetComponent<WebCard>().texturizeCard(translatedCard);
+      }
+      else
+      {
+        displayCard.GetComponent<WebCard>().texturizeCard(card);
+      }
       if (card.hasBackSide())
       {
         CardInfo backCard = PlayerManager.Instance.getCardFromLookup(card.backId);


### PR DESCRIPTION
## What does this Pull Request do?

- If a player packs a non-english language card in their opened store pack, the translation will show up in the card display highlight