### PR TITLE
MTG2D-35: Fix the image URL for meld backside cards

### DIFF
--- a/Assets/Resources/Sets/BRO.json
+++ b/Assets/Resources/Sets/BRO.json
@@ -5547,7 +5547,7 @@
         },
         {
             "id": "a36682d1-8f05-5039-a892-9ce0072591cf",
-            "imageUrl": "https://cards.scryfall.io/normal/back/0/2/0220c1e9-07bc-44f0-b39e-ca345ec4ea28.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/0/2/0220c1e9-07bc-44f0-b39e-ca345ec4ea28.jpg",
             "name": "Mishra, Lost to Phyrexia",
             "text": "Double strike\nWhen Phyrexian Dragon Engine enters the battlefield from your graveyard, you may discard your hand. If you do, draw three cards.\nUnearth {3}{R}{R}\n(Melds with Mishra, Claimed by Gix.)",
             "colours": [
@@ -8226,7 +8226,7 @@
         },
         {
             "id": "286fd366-82c8-5948-8101-d10bcf67fbf1",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/0/40a01679-3224-427e-bd1d-b797b0ab68b7.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/0/40a01679-3224-427e-bd1d-b797b0ab68b7.jpg",
             "name": "Urza, Planeswalker",
             "text": "When The Mightstone and Weakstone enters the battlefield, choose one \u2014\n\u2022 Draw two cards.\n\u2022 Target creature gets -5/-5 until end of turn.\n{T}: Add {C}{C}. This mana can't be spent to cast nonartifact spells.\n(Melds with Urza, Lord Protector.)",
             "colours": [
@@ -8814,7 +8814,7 @@
         },
         {
             "id": "8736023c-a553-572a-a00c-07fca44030a8",
-            "imageUrl": "https://cards.scryfall.io/normal/back/4/1/414b9230-9d25-4bdf-8b1e-b4fa2035b6a4.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/4/1/414b9230-9d25-4bdf-8b1e-b4fa2035b6a4.jpg",
             "name": "Titania, Gaea Incarnate",
             "text": "Argoth, Sanctum of Nature enters the battlefield tapped unless you control a legendary green creature.\n{T}: Add {G}.\n{2}{G}{G}, {T}: Create a 2/2 green Bear creature token, then mill three cards. Activate only as a sorcery.\n(Melds with Titania, Voice of Gaea.)",
             "colours": [

--- a/Assets/Resources/Sets/EMN.json
+++ b/Assets/Resources/Sets/EMN.json
@@ -499,7 +499,7 @@
         },
         {
             "id": "1b18ca2b-4e5e-54c1-bf43-1f32afa75f78",
-            "imageUrl": "https://cards.scryfall.io/normal/back/5/a/5a7a212e-e0b6-4f12-a95c-173cae023f93.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/5/a/5a7a212e-e0b6-4f12-a95c-173cae023f93.jpg",
             "name": "Brisela, Voice of Nightmares",
             "text": "When you cast Bruna, the Fading Light, you may return target Angel or Human creature card from your graveyard to the battlefield.\nFlying, vigilance\n(Melds with Gisela, the Broken Blade.)",
             "colours": [],
@@ -3425,7 +3425,7 @@
         },
         {
             "id": "3f8cdafb-10d5-510a-b908-49dd4c80fff3",
-            "imageUrl": "https://cards.scryfall.io/normal/back/7/0/70b94f21-4f01-46f8-ad50-e2bb0b68ea33.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/7/0/70b94f21-4f01-46f8-ad50-e2bb0b68ea33.jpg",
             "name": "Chittering Host",
             "text": "When Midnight Scavengers enters the battlefield, you may return target creature card with converted mana cost 3 or less from your graveyard to your hand.\n(Melds with Graf Rats.)",
             "colours": [],
@@ -4666,7 +4666,7 @@
         },
         {
             "id": "90a1aef4-314c-580d-8f64-fcddcafb474f",
-            "imageUrl": "https://cards.scryfall.io/normal/back/6/7/671fe14d-0070-4bc7-8983-707b570f4492.jpg",
+            "imageUrl": "https://cards.scryfall.io/normal/front/6/7/671fe14d-0070-4bc7-8983-707b570f4492.jpg",
             "name": "Hanweir, the Writhing Township",
             "text": "Whenever Hanweir Garrison attacks, put two 1/1 red Human creature tokens onto the battlefield tapped and attacking.\n(Melds with Hanweir Battlements.)",
             "colours": [],

--- a/MTG-Docs/CardDatabase/getCardsFromAllSets.py
+++ b/MTG-Docs/CardDatabase/getCardsFromAllSets.py
@@ -168,6 +168,7 @@ includedSets = [
     "CMM",
     "WOE",
     "LCI",
+    "PIP",
     "MKM",
     "OTJ"
 ]
@@ -250,7 +251,10 @@ for setCode in includedSets:
         imageUrl = ""
         scryfallId = card["identifiers"]["scryfallId"]
         if isBack:
-            imageUrl = "https://cards.scryfall.io/" + imageSize + "/back/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
+            if layout == "meld":
+                imageUrl = "https://cards.scryfall.io/" + imageSize + "/front/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
+            else:
+                imageUrl = "https://cards.scryfall.io/" + imageSize + "/back/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
         else:
             imageUrl = "https://cards.scryfall.io/" + imageSize + "/front/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
 
@@ -347,6 +351,11 @@ for setCode in includedSets:
     print("Completed set " + setCode + " [ " + str(setCounter) + " / " + str(len(includedSets)) + " ]")
     setCounter += 1
 
+    # Encode outputSet into JSON format and write to output JSON file
+    outputJSON = json.dumps(outputSet, indent=4)
+    with open(setOutputPath, "w") as outputFile:
+        outputFile.write(outputJSON)
+
     # Send id list to API
     if len(sys.argv) == 2 and sys.argv[1] == "-u":
         print("Sending to server...")
@@ -355,8 +364,3 @@ for setCode in includedSets:
         postResponse = requests.post(postUrl + '/cards', json=postPayload)
         print('Server response status code ' + str(postResponse.status_code))
         continue
-
-    # Encode outputSet into JSON format and write to output JSON file
-    outputJSON = json.dumps(outputSet, indent=4)
-    with open(setOutputPath, "w") as outputFile:
-        outputFile.write(outputJSON)

--- a/MTG-Docs/CardDatabase/getCardsFromSet.py
+++ b/MTG-Docs/CardDatabase/getCardsFromSet.py
@@ -99,7 +99,10 @@ for card in cards:
     imageUrl = ""
     scryfallId = card["identifiers"]["scryfallId"]
     if isBack:
-        imageUrl = "https://cards.scryfall.io/" + imageSize + "/back/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
+        if layout == "meld":
+            imageUrl = "https://cards.scryfall.io/" + imageSize + "/front/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
+        else:
+            imageUrl = "https://cards.scryfall.io/" + imageSize + "/back/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
     else:
         imageUrl = "https://cards.scryfall.io/" + imageSize + "/front/" + scryfallId[0] + "/" + scryfallId[1] + "/" + scryfallId + ".jpg"
 


### PR DESCRIPTION
## What does this Pull Request do?

- Fix the broken URLs on the backside of cards with the "meld" mechanic. (Affected sets: EMN / BRO)
- Set preprocessing scripts altered accordingly in order for them to generate the correct URL for any upcoming sets